### PR TITLE
Used stable version of android gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         // NOTE: Get latest version from github to avoid:
         // Error:Cause: com.android.sdklib.repository.FullRevision
         // https://github.com/JakeWharton/sdk-manager-plugin/pull/100


### PR DESCRIPTION
Lint gradle task was broken in 2.0.0-alpha3, reverted to latest stable version.